### PR TITLE
feat: support pull request workflows

### DIFF
--- a/.github/workflows/devops-vars.yml
+++ b/.github/workflows/devops-vars.yml
@@ -167,17 +167,23 @@ jobs:
         shell: bash
         run: |
           #!/bin/bash
-          if [ ${{ steps.set-deployment-env-vars.outputs.DEVOPS_IS_FEATURE_BRANCH }} = true ]; then
-            if [ ${{ steps.set-jira-ticket-id.outputs.DEVOPS_JIRA_TICKET_ID }} != 'N/A' ]; then
-              echo "Setting DEVOPS_ENV_NAME to be equal to DEVOPS_JIRA_TICKET_ID";
-              echo "DEVOPS_BRANCH_ENV_NAME=${{ steps.set-jira-ticket-id.outputs.DEVOPS_JIRA_TICKET_ID }}" >> $GITHUB_OUTPUT;
-            else
-              echo "Setting DEVOPS_ENV_NAME to be equal to GITHUB_REF_NAME";
-              echo "DEVOPS_BRANCH_ENV_NAME=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT;
-            fi;
+          # First, check if this is a PR. If so, set the branch name to be the PR number
+          if [ ${{ github.event_name }} = 'pull_request' ]; then
+            echo "Setting DEVOPS_BRANCH_ENV_NAME to be equal to the pull request number";
+            echo "DEVOPS_BRANCH_ENV_NAME=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT;
           else
-            echo "Setting DEVOPS_ENV_NAME to be equal to DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME";
-            echo "DEVOPS_BRANCH_ENV_NAME=${{ steps.set-deployment-env-vars.outputs.DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME }}" >> $GITHUB_OUTPUT;
+            if [ ${{ steps.set-deployment-env-vars.outputs.DEVOPS_IS_FEATURE_BRANCH }} = true ]; then
+              if [ ${{ steps.set-jira-ticket-id.outputs.DEVOPS_JIRA_TICKET_ID }} != 'N/A' ]; then
+                echo "Setting DEVOPS_ENV_NAME to be equal to DEVOPS_JIRA_TICKET_ID";
+                echo "DEVOPS_BRANCH_ENV_NAME=${{ steps.set-jira-ticket-id.outputs.DEVOPS_JIRA_TICKET_ID }}" >> $GITHUB_OUTPUT;
+              else
+                echo "Setting DEVOPS_ENV_NAME to be equal to GITHUB_REF_NAME";
+                echo "DEVOPS_BRANCH_ENV_NAME=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT;
+              fi;
+            else
+              echo "Setting DEVOPS_ENV_NAME to be equal to DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME";
+              echo "DEVOPS_BRANCH_ENV_NAME=${{ steps.set-deployment-env-vars.outputs.DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME }}" >> $GITHUB_OUTPUT;
+            fi;
           fi;
 
       - name: Echo DEVOPS_BRANCH_ENV_NAME


### PR DESCRIPTION
The devops-vars jobs are "push" focused. This change allows them to run on pull requests and determine values based on a workflow for pull requests.

## Example of a Deployment
<img width="867" alt="Screenshot 2024-05-22 at 8 21 18 AM" src="https://github.com/VirdocsSoftware/github-actions/assets/974421/ec8d489c-e152-4133-8fdd-27dab89f3dc2">

## Example of a Teardown
<img width="939" alt="Screenshot 2024-05-22 at 8 22 01 AM" src="https://github.com/VirdocsSoftware/github-actions/assets/974421/3625771f-160f-4782-bf57-77216a4a7d3c">
