### PR TITLE
chore: set default variables for branch names

### DIFF
--- a/.github/workflows/devops-vars.yml
+++ b/.github/workflows/devops-vars.yml
@@ -5,14 +5,6 @@ on:
         description: "A boolean flag used to enable the deployment of CloudFormation for feature branches. Will deploy if true."
         type: boolean
         default: false
-      DEVOPS_BRANCH_NAME_DEV:
-        description: "The name of the branch that indicates a deployment to the 'DEV' environment."
-        type: string
-        default: 'develop'
-      DEVOPS_BRANCH_NAME_UAT:
-        description: "The name of the branch that indicates a deployment to the 'UAT' environment."
-        type: string
-        default: 'uat'
     outputs:
       DEVOPS_BRANCH_ENV_NAME:
         description: "A value to append to CloudFormation stack names and AWS resource names for the purpose of unique names."
@@ -73,8 +65,8 @@ jobs:
         id: set-deployment-env-vars
         env:
           GITHUB_BRANCH_NAME: ${{ github.ref_name }}
-          BRANCH_NAME_DEV: ${{ vars.DEVOPS_BRANCH_NAME_DEV }}
-          BRANCH_NAME_UAT: ${{ vars.DEVOPS_BRANCH_NAME_UAT }}
+          BRANCH_NAME_DEV: ${{ vars.DEVOPS_BRANCH_NAME_DEV || 'develop' }}
+          BRANCH_NAME_UAT: ${{ vars.DEVOPS_BRANCH_NAME_UAT || 'uat' }}
           BRANCH_NAME_DEMO: ${{ vars.DEVOPS_BRANCH_NAME_DEMO }}
           BRANCH_NAME_PROD: ${{ vars.DEVOPS_BRANCH_NAME_PROD }}
         shell: bash

--- a/.github/workflows/devops-vars.yml
+++ b/.github/workflows/devops-vars.yml
@@ -117,7 +117,7 @@ jobs:
             # In case none of the above occurs
             echo "Setting DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME to be ${{ vars.DEVOPS_ENV_NAME_DEV }}";
             echo "DEVOPS_CURRENT_DEPLOYMENT_ENV_NAME=${{ vars.DEVOPS_ENV_NAME_DEV }}" >> $GITHUB_OUTPUT;
-            echo "Setting DEVOPS_IS_FEATURE_BRANCH to 'true' becuase this is not one of the four named environment branches.";
+            echo "Setting DEVOPS_IS_FEATURE_BRANCH to 'true' because this is not one of the four named environment branches.";
             echo "DEVOPS_IS_FEATURE_BRANCH=true" >> $GITHUB_OUTPUT;
             echo "DEVOPS_IS_ENV_DEV=true" >> $GITHUB_OUTPUT;
           fi;

--- a/.github/workflows/devops-vars.yml
+++ b/.github/workflows/devops-vars.yml
@@ -5,6 +5,14 @@ on:
         description: "A boolean flag used to enable the deployment of CloudFormation for feature branches. Will deploy if true."
         type: boolean
         default: false
+      DEVOPS_BRANCH_NAME_DEV:
+        description: "The name of the branch that indicates a deployment to the 'DEV' environment."
+        type: string
+        default: 'develop'
+      DEVOPS_BRANCH_NAME_UAT:
+        description: "The name of the branch that indicates a deployment to the 'UAT' environment."
+        type: string
+        default: 'uat'
     outputs:
       DEVOPS_BRANCH_ENV_NAME:
         description: "A value to append to CloudFormation stack names and AWS resource names for the purpose of unique names."


### PR DESCRIPTION
Many repositories are not setting the variables and assume the `DEVOPS_IS_ENV_DEV` is true for the `develop` branch by default. This change will make that a reality.