### PR TITLE
fix: pass the jira-username as a secret (CORE-1490)

### DIFF
--- a/.github/workflows/tag-tickets-with-release.yml
+++ b/.github/workflows/tag-tickets-with-release.yml
@@ -19,13 +19,12 @@ on:
         type: boolean
         required: false
         default: false
-      jira-username:
-        description: "The JIRA username to tag the release."
-        type: string
-        required: true
     secrets:
       llm-api-token:
         description: "A valid LLM API token to be used by the action."
+        required: true
+      jira-username:
+        description: "The JIRA username to tag the release."
         required: true
       jira-api-token:
         description: "A valid JIRA API token to be used by the action."
@@ -65,7 +64,7 @@ jobs:
           description: ${{ steps.llm_action.outputs.response }}
           target-branch: ${{ inputs.target-branch }}
           jira-token: ${{ secrets.jira-api-token }}
-          jira-email: ${{ inputs.jira-username }}
+          jira-email: ${{ secrets.jira-username }}
           jira-domain: ${{ inputs.jira-domain }}
           dry-run: ${{ inputs.dry-run }}
           is-release: ${{ inputs.is-release }}


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/zOvBKUUEERdNm/giphy.gif" />

### Description:

The tag-tickets-with-release job is not working

### Ticket:

https://virdocs.atlassian.net/browse/CORE-1490


### Changes: (complexity: 1)

- [ ] Pass the jira-username as a secret

### Validation:

- [ ] See https://github.com/VirdocsSoftware/toolbox/actions/runs/12056123413/job/33618009763
