### PR TITLE
feat: reference jira-username from secrets (CORE-1661)

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,15 +5,14 @@ on:
         description: "The parent page to create the release notes."
         type: string
         required: true
-      jira-username:
-        description: "The JIRA username to tag the release."
-        type: string
-        required: true
       jira-domain:
         description: "The JIRA domain to tag the release."
         type: string
         required: true
     secrets:
+      jira-username:
+        description: "The JIRA username to tag the release."
+        required: true
       jira-api-token:
         description: "The JIRA API token to tag the release."
         required: true

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           version: ${{ env.version }}
           parent-page: ${{ inputs.parent-page-id }}
-          jira-username: ${{ inputs.jira-username }}
+          jira-username: ${{ secrets.jira-username }}
           jira-domain: ${{ inputs.jira-domain }}
           jira-api-token: ${{ secrets.jira-api-token }}


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/zOvBKUUEERdNm/giphy.gif" />

### Description:

The jira username can be a secret.  Therefore, it has to be treated as one

### Ticket:

https://virdocs.atlassian.net/browse/CORE-1661


### Changes: (complexity: 1)

- [ ] Reference the jira-username as a secret
