### PR TITLE
fix: release notes execution error (CORE-1661)

### DIFF
--- a/.github/actions/confluence-release-notes/action.yml
+++ b/.github/actions/confluence-release-notes/action.yml
@@ -31,19 +31,8 @@ runs:
         REPOSITORY_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
         RELEASE_NAME=$(echo $REPOSITORY_NAME-v$VERSION)
         echo "RELEASE_NAME=$RELEASE_NAME"
-        JQL="fixVersion = $RELEASE_NAME"
-        ${{ github.action_path }}/jira_find_tickets.sh "$JQL" > jira_tickets.json
-        echo "*** JIRA Tickets ***"
-        cat jira_tickets.json
-        node ${{ github.action_path }}/generate_release_notes.js jira_tickets.json ${{ github.action_path }}/release_notes.html
-        echo "*** Release Notes ***"
-        cat ${{ github.action_path }}/release_notes.html
-        YEAR=$(date +'%Y')
         DATE=$(date +'%Y-%m-%d')
-        ${{ github.action_path }}/confluence_create_release_page.sh "$YEAR" "$RELEASE_NAME" "$DATE" ${{ github.action_path }}/release_notes.html > results.json
-        echo "*** Results ***"
-        cat results.json
-        jq -r '"\(.["_links"].base)\(.["_links"].webui)"' results.json
+        ${{ github.action_path }}/jira_release_notes.sh "$RELEASE_NAME" "$DATE"
       env:
         VERSION: ${{ inputs.version }}
         JIRA_USERNAME: ${{ inputs.jira-username }}

--- a/.github/actions/confluence-release-notes/jira_get_ticket.sh
+++ b/.github/actions/confluence-release-notes/jira_get_ticket.sh
@@ -38,6 +38,6 @@ TICKET_INFO=$($CURL_CMD \
   -X GET \
   --user ${USERNAME}:${TOKEN} \
   -H "Content-Type: application/json" \
-  "https://$JIRA_DOMAIN.atlassian.net/rest/api/2/issue/$TICKET_ID$EXPAND" 2>/dev/null)
+  "https://$JIRA_DOMAIN/rest/api/2/issue/$TICKET_ID$EXPAND" 2>/dev/null)
 
 echo $TICKET_INFO | jq .

--- a/.github/actions/confluence-release-notes/jira_get_ticket.sh
+++ b/.github/actions/confluence-release-notes/jira_get_ticket.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+JIRA_CONFIG="$($SCRIPT_DIR/jira_get_config.sh)"
+
+TOKEN=$(echo $JIRA_CONFIG | jq -r .auth.token)
+USERNAME=$(echo $JIRA_CONFIG | jq -r .auth.user)
+JIRA_DOMAIN=$(echo $JIRA_CONFIG | jq -r .jira.domain)
+
+if [ "$CURL_CMD" == "" ]; then
+  CURL_CMD="$(which curl)"
+fi
+
+if [ "$JIRA_DOMAIN" == "" ] || [ "$JIRA_DOMAIN" == "null" ]; then
+  echo "Please set the jira domain in the config file"
+  exit
+fi
+
+if [ "$1" == "" ]; then
+  echo "Usage: [ticket id] (option)"
+  echo " options:"
+  echo "    --history -h: show usage history"
+  echo "    --links   -l: show web links"
+  exit 1
+fi
+
+if [ "$2" == "--history" ] || [ "$2" == "-h" ]; then
+  EXPAND="?expand=changelog"
+elif [ "$2" == "--links" ] || [ "$2" == "-l" ]; then
+  EXPAND="/remotelink"
+else
+  EXPAND=
+fi
+
+TICKET_ID=$1
+
+TICKET_INFO=$($CURL_CMD \
+  -X GET \
+  --user ${USERNAME}:${TOKEN} \
+  -H "Content-Type: application/json" \
+  "https://$JIRA_DOMAIN.atlassian.net/rest/api/2/issue/$TICKET_ID$EXPAND" 2>/dev/null)
+
+echo $TICKET_INFO | jq .

--- a/.github/actions/confluence-release-notes/jira_release_notes.sh
+++ b/.github/actions/confluence-release-notes/jira_release_notes.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage {
+  echo "Usage: [fixVersion] [releaseDate: YYYY-MM-DD]"
+  exit 1
+}
+
+function validate_input {
+  if [ -z "$1" ] || [ -z "$2" ]; then
+    usage
+  fi
+  if [ ! "$2" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]; then
+    usage
+  fi
+}
+
+function main {
+  local fixVersion=$1
+  local releaseDate=$2
+  echo "RELEASE_NAME=$fixVersion"
+  JQL="fixVersion = $fixVersion"
+  local jira_ticket_file=$(mktemp)
+  $SCRIPT_DIR/jira_find_tickets.sh "$JQL" > $jira_ticket_file
+  echo "*** JIRA Tickets ***"
+  cat $jira_ticket_file
+  local release_notes_file=$(mktemp)
+  node $SCRIPT_DIR/generate_release_notes.js $jira_ticket_file $release_notes_file
+  echo "*** Release Notes ***"
+  cat $release_notes_file
+  YEAR=$(echo $releaseDate | cut -d'-' -f1)
+  DATE=$releaseDate
+  local results_file=$(mktemp)
+  bash $SCRIPT_DIR/confluence_create_release_page.sh "$YEAR" "$fixVersion" "$DATE" $release_notes_file > $results_file
+  echo "*** Results ***"
+  cat $results_file
+  jq -r '"\(.["_links"].base)\(.["_links"].webui)"' $results_file
+}
+
+validate_input "$1" "$2"
+main "$1" "$2"
+exit $?

--- a/.github/actions/confluence-release-notes/jira_release_notes.sh
+++ b/.github/actions/confluence-release-notes/jira_release_notes.sh
@@ -12,7 +12,7 @@ function validate_input {
   if [ -z "$1" ] || [ -z "$2" ]; then
     usage
   fi
-  if [ ! "$2" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]; then
+  if [[ ! "$2" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     usage
   fi
 }


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/BsQAVgY6ksvIY/giphy.gif?cid=790b7611h2cx9quc9mlg9fsrbwyf2zgoo9waznz9ueriz9ss&ep=v1_gifs_search&rid=giphy.gif&ct=g" />

### Description:

The release notes job failed in production.

### Ticket:

https://virdocs.atlassian.net/browse/CORE-1661


### Changes: (complexity: 2)

- [ ] Add missing script
- [ ] Add updated release notes script

### Validation:

- [ ] Set the `PARENT_PAGE_ID` environment variable by following these instructions: https://virdocs.atlassian.net/wiki/x/DgBuFgE
- [ ] Set up your Jira API environment variables (JIRA_API_TOKEN, JIRA_USERNAME, JIRA_DOMAIN)
- [ ] Run the `jira_release_notes.sh` script locally. 
