### PR TITLE
feat: ignore cancelled tickets (CORE-1691)

### DIFF
--- a/.github/actions/tag-jira-release/jira_tag_tickets.sh
+++ b/.github/actions/tag-jira-release/jira_tag_tickets.sh
@@ -107,7 +107,7 @@ function get_tickets_in_current_branch() {
   echo "Checking for tickets between $(get_current_branch) and $target_branch" >&2
   local ticket_info="$($TICKET_STATUS_PATH $(get_current_branch) $target_branch)"
   echo "$ticket_info" >&2
-  echo "$ticket_info" | grep -v '"Done"' | jq -r .url | sort | uniq | sed 's/https:\/\/'$JIRA_DOMAIN'\/browse\///g'
+  echo "$ticket_info" | grep -v '"Done"' | grep -v "Cancelled" | jq -r .url | sort | uniq | sed 's/https:\/\/'$JIRA_DOMAIN'\/browse\///g'
 }
 
 function existing_version() {


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/wvviImXiPDCko/giphy.gif?cid=ecf05e47nrvo3pbp369uwmtia0furwlggz4grkgq40ze1ejt&ep=v1_gifs_related&rid=giphy.gif&ct=g" />

### Description:

Cancelled tickets should not be included in a release

### Ticket:

https://virdocs/browse/CORE-1691


### Changes: (complexity: very simple)

- [ ] Change script to filter out Jira tickets with a Cancelled status

### Validation:

- [ ] Extract and run the command locally
```
export ticket_info='{"url":"https://virdocs.atlassian.net/browse/CORE-1234","status":"Cancelled"}'
export JIRA_DOMAIN="virdocs.atlassian.net"
echo "$ticket_info" | grep -v '"Done"' | grep -v "Cancelled" | jq -r .url | sort | uniq | sed 's/https:\/\/'$JIRA_DOMAIN'\/browse\///g'
```
The output is an empty string