### PR TITLE
fix: use the correct git log history (CORE-1734)

### DIFF
--- a/.github/actions/predict-next-version/git_predict_next_version.sh
+++ b/.github/actions/predict-next-version/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log HEAD..origin/main
+    git log origin/main..HEAD
   else
     echo "$GIT_LOGS"
   fi

--- a/.github/actions/predict-next-version/git_predict_next_version.sh
+++ b/.github/actions/predict-next-version/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log $(git merge-base HEAD origin/main)..HEAD
+    git log HEAD..origin/main
   else
     echo "$GIT_LOGS"
   fi

--- a/.github/actions/tag-jira-release/git_predict_next_version.sh
+++ b/.github/actions/tag-jira-release/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log HEAD..$TARGET_BRANCH
+    git log $TARGET_BRANCH..HEAD
   else
     echo "$GIT_LOGS"
   fi

--- a/.github/actions/tag-jira-release/git_predict_next_version.sh
+++ b/.github/actions/tag-jira-release/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log $(git merge-base HEAD ${TARGET_BRANCH})..HEAD
+    git log HEAD..$TARGET_BRANCH
   else
     echo "$GIT_LOGS"
   fi

--- a/.github/actions/tag-jira-release/ticket_status.sh
+++ b/.github/actions/tag-jira-release/ticket_status.sh
@@ -20,7 +20,7 @@ if [ "$2" != "" ]; then
   TARGET_BRANCH=$2
 fi
 
-HASHES=$(git log $CURRENT_BRANCH..$TARGET_BRANCH --pretty=format:'%H')
+HASHES=$(git log $TARGET_BRANCH..$CURRENT_BRANCH --pretty=format:'%H')
 
 if [ ! -d ~/temp ]; then
   mkdir ~/temp

--- a/.github/actions/tag-jira-release/ticket_status.sh
+++ b/.github/actions/tag-jira-release/ticket_status.sh
@@ -20,8 +20,7 @@ if [ "$2" != "" ]; then
   TARGET_BRANCH=$2
 fi
 
-COMMON_BRANCH=$(git merge-base $TARGET_BRANCH $CURRENT_BRANCH)
-HASHES=$(git log $COMMON_BRANCH..$CURRENT_BRANCH --pretty=format:'%H')
+HASHES=$(git log $CURRENT_BRANCH..$TARGET_BRANCH --pretty=format:'%H')
 
 if [ ! -d ~/temp ]; then
   mkdir ~/temp

--- a/.github/workflows/tag-tickets-with-release.yml
+++ b/.github/workflows/tag-tickets-with-release.yml
@@ -52,9 +52,8 @@ jobs:
             TARGET_BRANCH="origin/main"
           fi
           echo "Finding the common branch between HEAD and ${TARGET_BRANCH}" >&2
-          COMMON_BRANCH=$(git merge-base HEAD ${TARGET_BRANCH})
-          echo "Retrieving the git log between ${COMMON_BRANCH} and HEAD" >&2
-          DIFF="$(git log --pretty=format:'%s' ${COMMON_BRANCH}..HEAD)"
+          echo "Retrieving the git log between ${TARGET_BRANCH} and HEAD" >&2
+          DIFF="$(git log --pretty=format:'%s' HEAD..$TARGET_BRANCH)"
           LLM_PROMPT_PREFIX="Create a fun release description in 100 characters or less in one line without identifiers for the following data:
           "
           LLM_PROMPT="$LLM_PROMPT_PREFIX$DIFF"

--- a/.github/workflows/tag-tickets-with-release.yml
+++ b/.github/workflows/tag-tickets-with-release.yml
@@ -53,7 +53,7 @@ jobs:
           fi
           echo "Finding the common branch between HEAD and ${TARGET_BRANCH}" >&2
           echo "Retrieving the git log between ${TARGET_BRANCH} and HEAD" >&2
-          DIFF="$(git log --pretty=format:'%s' HEAD..$TARGET_BRANCH)"
+          DIFF="$(git log --pretty=format:'%s' $TARGET_BRANCH..HEAD)"
           LLM_PROMPT_PREFIX="Create a fun release description in 100 characters or less in one line without identifiers for the following data:
           "
           LLM_PROMPT="$LLM_PROMPT_PREFIX$DIFF"

--- a/tooling/scripts/git_predict_next_version.sh
+++ b/tooling/scripts/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log HEAD..origin/main
+    git log origin/main..HEAD
   else
     echo "$GIT_LOGS"
   fi

--- a/tooling/scripts/git_predict_next_version.sh
+++ b/tooling/scripts/git_predict_next_version.sh
@@ -30,7 +30,7 @@ git fetch
 
 function get_logs() {
   if [ "$GIT_LOGS" == "" ]; then
-    git log $(git merge-base HEAD origin/main)..HEAD
+    git log HEAD..origin/main
   else
     echo "$GIT_LOGS"
   fi


### PR DESCRIPTION
<img width="250" src="https://icbainc.com/wp-content/uploads/2017/06/RedShelf-300x192.png" />

### Description:

Use the same git log command that GitHub does

### Ticket:

https://virdocs.atlassian.net/browse/CORE-1734


### Changes: (complexity: low)

- [ ] Use the command `git log ${target_branch}..HEAD` which is the same command that GitHub uses to get the git commits between branches

### Validation:

- [ ] See https://stackoverflow.com/questions/13965391/how-do-i-see-the-commit-differences-between-branches-in-git
