### PR TITLE
fix: properly compare versions (CORE-1873)

### DIFF
--- a/.github/actions/validate-pr/validate_pr_test.sh
+++ b/.github/actions/validate-pr/validate_pr_test.sh
@@ -217,3 +217,18 @@ ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
 
 # THEN
 expect "$?" "0"
+
+echo Scenario: Next release version has double digit and current release version has single digit
+beforeEach
+
+# GIVEN
+export PR_BRANCH="release/v1.10.0"
+export TARGET_BRANCH="main"
+export PACKAGE_VERSION="1.10.0"
+export LATEST_RELEASE="1.9.0"
+
+# WHEN
+ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
+
+# THEN
+expect "$?" "0"


### PR DESCRIPTION
<img width="250" src="https://icbainc.com/wp-content/uploads/2017/06/RedShelf-300x192.png" />

### Description:

The pr-hygine job is failing to properly compare versions. v2.10.0 is higher than v2.9.0

### Ticket:

https://virdocs.atlassian.net/browse/CORE-1873


### Changes: (complexity: ?)

- [ ] Change 1

### Validation:

- [ ] Validation 1
