### PR TITLE
fix: CORE-1638 add to pr hygene error instructions

### DIFF
--- a/.github/actions/validate-pr/validate_pr.sh
+++ b/.github/actions/validate-pr/validate_pr.sh
@@ -80,7 +80,7 @@ Details:
 Action: Update the PR title to start with a valid semantic prefix
 Valid prefixes: feat:, fix:, chore:, docs:, style:, refactor:, perf:, test:
 Example: feat: Add new feature (ABC-123)
-Note: You must push a new commit in order to update this validation result"
+Note: You must push a new commit to update this validation result"
     exit 1
   fi
 

--- a/.github/actions/validate-pr/validate_pr.sh
+++ b/.github/actions/validate-pr/validate_pr.sh
@@ -79,7 +79,8 @@ Details:
 - Current title: $PR_TITLE
 Action: Update the PR title to start with a valid semantic prefix
 Valid prefixes: feat:, fix:, chore:, docs:, style:, refactor:, perf:, test:
-Example: feat: Add new feature (ABC-123)"
+Example: feat: Add new feature (ABC-123)
+Note: You must push a new commit in order to update this validation result"
     exit 1
   fi
 

--- a/.github/actions/validate-pr/validate_pr_test.sh
+++ b/.github/actions/validate-pr/validate_pr_test.sh
@@ -42,7 +42,8 @@ Details:
 - Current title: This is a PR title (ISSUE-1234)
 Action: Update the PR title to start with a valid semantic prefix
 Valid prefixes: feat:, fix:, chore:, docs:, style:, refactor:, perf:, test:
-Example: feat: Add new feature (ABC-123)"
+Example: feat: Add new feature (ABC-123)
+Note: You must push a new commit to update this validation result"
 
 echo Scenario: PR title missing Jira ticket for feature branch
 beforeEach


### PR DESCRIPTION
This pull request includes minor changes to the PR title validation scripts to improve clarity in the validation messages.

* [`.github/actions/validate-pr/validate_pr.sh`](diffhunk://#diff-a16d0338c335555286965e8bf11685ff11923fea5459cbe5190cfd25047e3a75L82-R83): Updated the example PR title to remove an unnecessary quotation mark and added a note indicating that a new commit is required to update the validation result.
* [`.github/actions/validate-pr/validate_pr_test.sh`](diffhunk://#diff-04960a654e1a0d0d28d2f4a73bf29e448608a542e91fb39eba9c78753c6e11f2L45-R46): Updated the example PR title to remove an unnecessary quotation mark and added a note indicating that a new commit is required to update the validation result.