### PR TITLE
feat: support input version (UFA-1014)

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,6 +9,10 @@ on:
         description: "The JIRA domain to tag the release."
         type: string
         required: true
+      version:
+        description: "The version to tag the release."
+        type: string
+        required: false
     secrets:
       jira-username:
         description: "The JIRA username to tag the release."
@@ -27,7 +31,11 @@ jobs:
           fetch-depth: 0
       - name: Get Version
         run: |
-          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+          if [ -z "${{ inputs.version }}" ]; then
+            echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+          else
+            echo "version=${{ inputs.version }}" >> $GITHUB_ENV
+          fi
       - name: Create Confluence Release Notes
         uses: VirdocsSoftware/github-actions/.github/actions/confluence-release-notes@main
         with:


### PR DESCRIPTION
### Description:

We need to support creating release notes for all repositories

### Ticket:

https://virdocs.atlassian.net/browse/UFA-1014


### Changes: (complexity: low)

This pull request includes changes to the `.github/workflows/release-notes.yml` file to add a new input parameter for version tagging and handle its usage in the workflow.

Enhancements to release notes workflow:

* [`.github/workflows/release-notes.yml`](diffhunk://#diff-42244398366244a59eb9bb95d4d4f8f8657297b9e8e5bf3a815f3e8cca374ce1R12-R15): Added a new optional input parameter `version` to allow specifying a version for tagging the release.
* [`.github/workflows/release-notes.yml`](diffhunk://#diff-42244398366244a59eb9bb95d4d4f8f8657297b9e8e5bf3a815f3e8cca374ce1R34-R38): Modified the `Get Version` job to use the provided `version` input if available, otherwise default to extracting the version from `package.json`.

### Validation:

- [ ] A successful workflow run. See https://github.com/VirdocsSoftware/manager-app/actions/runs/13679378943/job/38247652028
