### PR TITLE
feat: set default ignored accounts and the ability to specify (RD-2964)

### DIFF
--- a/.github/actions/static-analysis/action.yml
+++ b/.github/actions/static-analysis/action.yml
@@ -1,6 +1,12 @@
 name: "Static Analysis"
 description: "Runs static analysis on the code"
 
+inputs:
+  ignored-accounts:
+    description: "Comma-separated list of accounts to ignore"
+    required: false
+    default: "actions,VirdocsSoftware"
+
 runs:
   using: "composite"
   steps:
@@ -13,3 +19,5 @@ runs:
         node ${{ github.action_path }}/scan_github_actions.js
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        IGNORED_ACCOUNTS: ${{ inputs.ignored-accounts }}

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -4,6 +4,7 @@ class StaticAnalysis {
         this.process = process;
         this.ignoredAccounts = ignoredAccounts;
         console.log(`Ignored accounts: ${this.ignoredAccounts}`);
+    }
 
     isCommitHash(ref) {
         return /^[0-9a-f]{40}$/.test(ref);

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -96,7 +96,8 @@ class DataProvider {
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
+const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').split(',');
 
 const dataProvider = new DataProvider(fs, path);
-const staticAnalysis = new StaticAnalysis(dataProvider, process);
+const staticAnalysis = new StaticAnalysis(dataProvider, process, ignoredAccounts);
 staticAnalysis.run();

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -3,7 +3,6 @@ class StaticAnalysis {
         this.dataProvider = dataProvider;
         this.process = process;
         this.ignoredAccounts = ignoredAccounts;
-        console.log(`Ignored accounts: ${this.ignoredAccounts}`);
     }
 
     isCommitHash(ref) {
@@ -33,7 +32,6 @@ class StaticAnalysis {
         while ((match = regex.exec(content)) !== null) {
             const ref = match[2];
             const account = match[1].split('/')[0];
-            console.log(`Account: ${account}`);
             if (this.ignoredAccounts.includes(account)) {
                 continue;
             }

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -32,7 +32,7 @@ class StaticAnalysis {
         let warnings = [];
         while ((match = regex.exec(content)) !== null) {
             const ref = match[2];
-            const account = match[1];
+            const account = match[1].split('/')[0];
             console.log(`Account: ${account}`);
             if (this.ignoredAccounts.includes(account)) {
                 continue;

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -27,13 +27,12 @@ class StaticAnalysis {
 
     scanFile(filePath) {
         const content = this.dataProvider.readFile(filePath);
-        const regex = /uses:\s*[\w-]+\/[\w-]+@([\w-.]+)/g;
+        const regex = /uses:\s*([\w-]+\/[\w-]+)@([\w-.]+)/g;
         let match;
         let warnings = [];
         while ((match = regex.exec(content)) !== null) {
-            const ref = match[1];
-            // extract the account from the ref
-            const account = ref.split('/')[0];
+            const ref = match[2];
+            const account = match[1];
             console.log(`Account: ${account}`);
             if (this.ignoredAccounts.includes(account)) {
                 continue;

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -3,7 +3,7 @@ class StaticAnalysis {
         this.dataProvider = dataProvider;
         this.process = process;
         this.ignoredAccounts = ignoredAccounts;
-    }
+        console.log(`Ignored accounts: ${this.ignoredAccounts}`);
 
     isCommitHash(ref) {
         return /^[0-9a-f]{40}$/.test(ref);
@@ -33,6 +33,7 @@ class StaticAnalysis {
             const ref = match[1];
             // extract the account from the ref
             const account = ref.split('/')[0];
+            console.log(`Account: ${account}`);
             if (this.ignoredAccounts.includes(account)) {
                 continue;
             }

--- a/.github/actions/static-analysis/scan_github_actions.js
+++ b/.github/actions/static-analysis/scan_github_actions.js
@@ -1,7 +1,8 @@
 class StaticAnalysis {
-    constructor(dataProvider, process) {
+    constructor(dataProvider, process, ignoredAccounts = []) {
         this.dataProvider = dataProvider;
         this.process = process;
+        this.ignoredAccounts = ignoredAccounts;
     }
 
     isCommitHash(ref) {
@@ -30,6 +31,11 @@ class StaticAnalysis {
         let warnings = [];
         while ((match = regex.exec(content)) !== null) {
             const ref = match[1];
+            // extract the account from the ref
+            const account = ref.split('/')[0];
+            if (this.ignoredAccounts.includes(account)) {
+                continue;
+            }
             if (!this.isCommitHash(ref)) {
                 warnings.push(`Warning: In file ${filePath}, '${match[0]}' does not use a commit hash.`);
             }


### PR DESCRIPTION
<img width="250" src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmV4cTMxYW8wdHQxNzM2dGM2dG5ubXg4azlkeHBubmh3MXNoZmwxNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/IdmfEtnMWPzOg/giphy.gif" />

### Description:

Support ignoring specified github accounts with the default being actions and VirdocsSoftware.

### Ticket:

https://virdocs.atlassian.net/browse/RD-2964


### Changes: (complexity: low)

This pull request introduces enhancements to the static analysis action by adding support for ignoring specific accounts. The key changes include updates to the action configuration and modifications to the static analysis script to handle the new input.

Enhancements to static analysis action:

* [`.github/actions/static-analysis/action.yml`](diffhunk://#diff-ce5528a1c296df8e97111445d5eb68705a40ead98c9a2e023df580444706422bR4-R9): Added a new input `ignored-accounts` to specify a comma-separated list of accounts to ignore during static analysis. This input is optional and defaults to "actions,VirdocsSoftware". [[1]](diffhunk://#diff-ce5528a1c296df8e97111445d5eb68705a40ead98c9a2e023df580444706422bR4-R9) [[2]](diffhunk://#diff-ce5528a1c296df8e97111445d5eb68705a40ead98c9a2e023df580444706422bR22-R23)

* [`.github/actions/static-analysis/scan_github_actions.js`](diffhunk://#diff-ae17b47aed06bacf6c54ade2e25faf01e30be5029862fc305734f79e6182f551L2-R5): Updated the `StaticAnalysis` class constructor to accept an `ignoredAccounts` parameter and modified the `scanFile` method to skip accounts listed in `ignoredAccounts`. [[1]](diffhunk://#diff-ae17b47aed06bacf6c54ade2e25faf01e30be5029862fc305734f79e6182f551L2-R5) [[2]](diffhunk://#diff-ae17b47aed06bacf6c54ade2e25faf01e30be5029862fc305734f79e6182f551L28-R37)

* [`.github/actions/static-analysis/scan_github_actions.js`](diffhunk://#diff-ae17b47aed06bacf6c54ade2e25faf01e30be5029862fc305734f79e6182f551R98-R101): Added logic to retrieve the `IGNORED_ACCOUNTS` environment variable, split it into an array, and pass it to the `StaticAnalysis` instance.

### Validation:

- [ ] Run the action from another workflow
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/d14715d3-505f-4330-af0e-524684677caf" />

