### PR TITLE
feat: support branch suffixes (CORE-2231)

### DIFF
--- a/.github/actions/validate-pr/validate_pr.sh
+++ b/.github/actions/validate-pr/validate_pr.sh
@@ -66,7 +66,7 @@ function compare_versions() {
 
 SEMANTIC_PREFIXES="^(feat|fix|chore|docs|style|refactor|perf|test)[(:]"
 JIRA_TICKET="([A-Z]+-[0-9]+)"
-VERSION_REGEX="^v([0-9]+)\.([0-9]+)\.([0-9]+)$"
+VERSION_REGEX="v([0-9]+)\.([0-9]+)\.([0-9]+)"
 
 if [[ "$TARGET_BRANCH" == "develop" ]] || [[ "$TARGET_BRANCH" =~ ^release/v ]] || [[ "$TARGET_BRANCH" =~ ^hotfix/v ]]; then
   if [[ "$PR_BRANCH" =~ ^release/v ]] || [[ "$PR_BRANCH" =~ ^hotfix/v ]]; then
@@ -96,7 +96,8 @@ fi
 
 if [[ "$TARGET_BRANCH" == "main" ]]; then
   if [[ "$PR_BRANCH" =~ ^release/v ]] || [[ "$PR_BRANCH" =~ ^hotfix/v ]]; then
-    if [[ ! "$PR_BRANCH" =~ ^release/v$PACKAGE_VERSION ]] && [[ ! "$PR_BRANCH" =~ ^hotfix/v$PACKAGE_VERSION ]]; then
+    BASE_BRANCH_VERSION=$(echo "$PR_BRANCH" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+")
+    if [[ ! "$BASE_BRANCH_VERSION" =~ ^v$PACKAGE_VERSION ]] && [[ ! "$BASE_BRANCH_VERSION" =~ ^v$PACKAGE_VERSION ]]; then
       echo "Error: Mismatch between the pull request branch and the package version.
 Details:
 - PR Branch: $PR_BRANCH
@@ -125,7 +126,7 @@ Action: Only release or hotfix branches can be merged to main
 Expected format: release/v$PACKAGE_VERSION or hotfix/v$PACKAGE_VERSION"
     exit 1
   fi
-  if [[ ! "$PR_BRANCH" =~ ^release/v$PACKAGE_VERSION ]] && [[ ! "$PR_BRANCH" =~ ^hotfix/v$PACKAGE_VERSION ]]; then
+  if [[ ! "$BASE_BRANCH_VERSION" =~ ^v$PACKAGE_VERSION ]] && [[ ! "$BASE_BRANCH_BRANCH" =~ ^v$PACKAGE_VERSION ]]; then
     echo "Error: Branch name does not match package version
 Details:
 - Current branch: $PR_BRANCH

--- a/.github/actions/validate-pr/validate_pr_test.sh
+++ b/.github/actions/validate-pr/validate_pr_test.sh
@@ -263,3 +263,19 @@ ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
 
 # THEN
 expect "$?" "0"
+
+echo Scenario: Valid hotfix branch with suffix to main branch
+beforeEach
+
+# GIVEN
+export PR_BRANCH="hotfix/v1.2.3-ar"
+export TARGET_BRANCH="main"
+export PACKAGE_VERSION="1.2.3"
+export LATEST_RELEASE="1.2.2"
+export PR_TITLE="hotfix v1.2.3 to main"
+
+# WHEN
+ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
+
+# THEN
+expect "$?" "0"


### PR DESCRIPTION
<img width="250" src="https://github.com/user-attachments/assets/6c6259a9-7c80-4896-aa66-93cb67eb026a" />

### Description:

Sometimes a suffix is needed in order to avoid collisions.
This pull request enhances the validate-pr.sh script to support branch names with suffixes (e.g., hotfix/v1.2.3-ar) while still matching the base version (v1.2.3). The changes ensure that branch suffixes do not interfere with version validation logic.

### Ticket:

https://virdocs.atlassian.net/browse/CORE-2231


### Changes: (complexity: low-medium)

- [ ] pdated the version extraction and validation logic.  Ensured compatibility with branch names containing suffixes.
- [ ] Added a new test case to verify the functionality of branch suffix handling.

### Validation:

- [ ] All tests pass
