### PR TITLE
feat: honor the skip-release-notes label (CORE-2259)

### DIFF
--- a/.github/actions/tag-jira-release/jira_tag_tickets.sh
+++ b/.github/actions/tag-jira-release/jira_tag_tickets.sh
@@ -107,7 +107,7 @@ function get_tickets_in_current_branch() {
   echo "Checking for tickets between $(get_current_branch) and $target_branch" >&2
   local ticket_info="$($TICKET_STATUS_PATH $(get_current_branch) $target_branch)"
   echo "$ticket_info" >&2
-  echo "$ticket_info" | grep -v '"Done"' | grep -v "Cancelled" | jq -r .url | sort | uniq | sed 's/https:\/\/'$JIRA_DOMAIN'\/browse\///g'
+  echo "$ticket_info" | grep -v '"Done"' | grep -v "Cancelled" | grep -v '"skip-release-notes"' | jq -r .url | sort | uniq | sed 's/https:\/\/'$JIRA_DOMAIN'\/browse\///g'
 }
 
 function existing_version() {

--- a/.github/actions/tag-jira-release/ticket_status.sh
+++ b/.github/actions/tag-jira-release/ticket_status.sh
@@ -48,6 +48,14 @@ function getTicketInfo() {
   fi
 }
 
+function hasSkipReleaseNotes() {
+  commitHash=$1
+  LOG=$($GIT_CMD show $commitHash | sed '/^diff/,$d')
+  if [[ "$LOG" =~ \[skip-release-notes\] ]]; then
+    echo -n ",\"skip-release-notes\":true"
+  fi
+}
+
 while IFS= read -r hash; do
   FILE=~/temp/$hash.txt
   if [ -f "$FILE" ]; then
@@ -55,6 +63,7 @@ while IFS= read -r hash; do
       if [ "$ticketId" != "" ]; then
         echo -n "{\"hash\":\"$hash\","
         getTicketInfo $ticketId
+        hasSkipReleaseNotes $hash
         echo "}"
       fi
     done <<< "$(cat $FILE | sed 's/ /\n/g')"

--- a/.github/actions/tag-jira-release/ticket_status.sh
+++ b/.github/actions/tag-jira-release/ticket_status.sh
@@ -50,7 +50,7 @@ function getTicketInfo() {
 
 function hasSkipReleaseNotes() {
   commitHash=$1
-  LOG=$($GIT_CMD show $commitHash | sed '/^diff/,$d')
+  LOG=$(git show $commitHash | sed '/^diff/,$d')
   if [[ "$LOG" =~ \[skip-release-notes\] ]]; then
     echo -n ",\"skip-release-notes\":true"
   fi


### PR DESCRIPTION
<img width="250" src="https://github.com/user-attachments/assets/6c6259a9-7c80-4896-aa66-93cb67eb026a" />

### Description:

Honor the skip-release-notes label on commit messages

### Ticket:

https://virdocs.atlassian.net/browse/CORE-2259


### Changes: (complexity: low)

- [ ] Scan for the skip-release-notes text in commit messages and add the property to the ticket status output json

### Validation:

- [ ] Run the ticket_status.sh script
```
mfa-prod (active)$ JIRA_DOMAIN=virdocs.atlassian.net ./ticket_status.sh . origin/develop | jq
{
  "hash": "6aafce3ed8f6df5250c13c48edd42304b06ac5a8",
  "url": "https://virdocs.atlassian.net/browse/CORE-2259",
  "status": "In Progress"
}
{
  "hash": "db14bb21da7ea4ff50cb71f2456a8e2e686f0444",
  "url": "https://virdocs.atlassian.net/browse/CORE-2259",
  "status": "In Progress",
  "skip-release-notes": true
}
```
