### PR TITLE
feat: support merging main to develop

### DIFF
--- a/.github/actions/validate-pr/validate_pr.sh
+++ b/.github/actions/validate-pr/validate_pr.sh
@@ -68,6 +68,11 @@ SEMANTIC_PREFIXES="^(feat|fix|chore|docs|style|refactor|perf|test)[(:]"
 JIRA_TICKET="([A-Z]+-[0-9]+)"
 VERSION_REGEX="v([0-9]+)\.([0-9]+)\.([0-9]+)"
 
+if [ "$PR_BRANCH" == "main" ] && [ "$TARGET_BRANCH" == "develop" ]; then
+  echo "Everything is good"
+  exit 0
+fi
+
 if [[ "$TARGET_BRANCH" == "develop" ]] || [[ "$TARGET_BRANCH" =~ ^release/v ]] || [[ "$TARGET_BRANCH" =~ ^hotfix/v ]]; then
   if [[ "$PR_BRANCH" =~ ^release/v ]] || [[ "$PR_BRANCH" =~ ^hotfix/v ]]; then
     echo "PR title and branch name validation passed."

--- a/.github/actions/validate-pr/validate_pr_test.sh
+++ b/.github/actions/validate-pr/validate_pr_test.sh
@@ -279,3 +279,19 @@ ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
 
 # THEN
 expect "$?" "0"
+
+echo Scenario: Valid main branch to develop branch
+beforeEach
+
+# GIVEN
+export PR_BRANCH="main"
+export TARGET_BRANCH="develop"
+export PACKAGE_VERSION="1.18.2"
+export LATEST_VERSION="1.18.2"
+export PR_TITLE="chore: sync main (v1.18.2) to develop"
+
+# WHEN
+ACTUAL="$($SCRIPT_DIR/validate_pr.sh)"
+
+# THEN
+expect "$?" "0"


### PR DESCRIPTION
<img width="250" src="https://camo.githubusercontent.com/36fd6eeea8fb6170dfd952a6275619000af02165b7470bca527b56e173c490c4/68747470733a2f2f69636261696e632e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031372f30362f5265645368656c662d333030783139322e706e67" />

### Description:

In the spirit of “The Patchwork Paradox,” Team Fox threads another stitch into the fabric of our codebase. This PR introduces support for merging `main` into `develop`—a subtle but essential seam that ensures our past releases and future features stay in sync. Like a well-placed patch, it’s small, but it holds everything together.

### Changes: (complexity: 🧵 low)

- [x] Updated `validate_pr.sh` to allow `main` → `develop` merges
- [x] Added test scenario in `validate_pr_test.sh` to validate this flow

### Validation:

- [x] Confirmed PR title and branch validation passes for `main` → `develop`
- [x] All existing checks remain green and untouched